### PR TITLE
remove type prefix

### DIFF
--- a/numfi/numfi.py
+++ b/numfi/numfi.py
@@ -1,8 +1,8 @@
 import numpy as np
 from typing import Literal
 import warnings
-type RoundingMethod_Enum = Literal['Nearest', 'Round', 'Convergent','Floor','Zero','Ceiling']
-type OverflowAction_Enum = Literal['Error','Wrap','Saturate']
+RoundingMethod_Enum = Literal['Nearest', 'Round', 'Convergent','Floor','Zero','Ceiling']
+OverflowAction_Enum = Literal['Error','Wrap','Saturate']
 
 def lshift(x, s):
     return x << s if s >= 0 else x >> -s

--- a/numfi/numfi.py
+++ b/numfi/numfi.py
@@ -1,6 +1,17 @@
 import numpy as np
-from typing import Literal
+from typing import Union, Optional, Any
 import warnings
+
+try:
+    from typing import Literal
+except ImportError:
+    # Fallback for Python < 3.8
+    class _LiteralMeta(type):
+        def __getitem__(cls, x):
+            return Any
+    class Literal(metaclass=_LiteralMeta):
+        pass
+
 RoundingMethod_Enum = Literal['Nearest', 'Round', 'Convergent','Floor','Zero','Ceiling']
 OverflowAction_Enum = Literal['Error','Wrap','Saturate']
 
@@ -8,7 +19,7 @@ def lshift(x, s):
     return x << s if s >= 0 else x >> -s
 
 class numfi(np.ndarray):
-    def __new__(cls, array=[], s:int|None|bool=None, w:int|None=None, f:int|None=None, **kwargs) -> 'numfi':
+    def __new__(cls, array=[], s:Union[int, None, bool]=None, w:Optional[int]=None, f:Optional[int]=None, **kwargs) -> 'numfi':
         # priority: explicit like > array
         like = kwargs.get('like', array)
         if issubclass(type(array),numfi):


### PR DESCRIPTION
Couldn't use numfi on my machine with the "type" prefix. Removing the "type" prefix made the module run without any issues. I'm new to Python, so maybe there's something else going on with the machine.